### PR TITLE
Allows seeding layouts

### DIFF
--- a/RAWSimO.Core/Configurations/LayoutConfiguration.cs
+++ b/RAWSimO.Core/Configurations/LayoutConfiguration.cs
@@ -31,6 +31,10 @@ namespace RAWSimO.Core.Configurations
         #region member variables 
 
         /// <summary>
+        /// The seed used to initialize the RNG.
+        /// </summary>
+        public int Seed = 0;
+        /// <summary>
         /// The number of tiers to generate.
         /// </summary>
         public int TierCount = 1;

--- a/RAWSimO.Core/Generator/InstanceGenerator.cs
+++ b/RAWSimO.Core/Generator/InstanceGenerator.cs
@@ -27,19 +27,17 @@ namespace RAWSimO.Core.Generator
         /// Generates an instance with the given layout and configuration attached.
         /// </summary>
         /// <param name="layoutConfiguration">The layout configuration defining all the instance characteristics.</param>
-        /// <param name="rand">A randomizer that is used during generation.</param>
         /// <param name="settingConfig">The configuration for the setting to emulate that will be attached for executing the simulation afterwards.</param>
         /// <param name="controlConfig">The configuration for the controlling mechanisms that will be attached for executing the simulation afterwards.</param>
         /// <param name="logAction">An optional action for logging.</param>
         /// <returns>The generated instance.</returns>
         public static Instance GenerateLayout(
             LayoutConfiguration layoutConfiguration,
-            IRandomizer rand,
             SettingConfiguration settingConfig,
             ControlConfiguration controlConfig,
             Action<string> logAction = null)
         {
-            LayoutGenerator layoutGenerator = new LayoutGenerator(layoutConfiguration, rand, settingConfig, controlConfig, logAction);
+            LayoutGenerator layoutGenerator = new LayoutGenerator(layoutConfiguration, settingConfig, controlConfig, logAction);
             Instance instance = layoutGenerator.GenerateLayout();
             InitializeInstance(instance);
             return instance;
@@ -69,7 +67,7 @@ namespace RAWSimO.Core.Generator
         /// <param name="settingConfig">The configuration for the setting to emulate that will be attached for executing the simulation afterwards.</param>
         /// <param name="controlConfig">The configuration for the controlling mechanisms that will be attached for executing the simulation afterwards.</param>
         /// <returns>The generated instance.</returns>
-        public static Instance GenerateMaTiLayoutPico(IRandomizer rand, SettingConfiguration settingConfig, ControlConfiguration controlConfig)
+        public static Instance GenerateMaTiLayoutPico(SettingConfiguration settingConfig, ControlConfiguration controlConfig)
         {
             LayoutConfiguration layoutConfiguration = GenerateMaTiLayoutConfiguration();
             layoutConfiguration.BotCount = 4;
@@ -84,7 +82,7 @@ namespace RAWSimO.Core.Generator
             layoutConfiguration.NReplenishmentStationEast = 0;
             layoutConfiguration.NReplenishmentStationSouth = 0;
             layoutConfiguration.NReplenishmentStationNorth = 0;
-            return GenerateLayout(layoutConfiguration, rand, settingConfig, controlConfig);
+            return GenerateLayout(layoutConfiguration, settingConfig, controlConfig);
         }
         /// <summary>
         /// Generates the nano default layout.
@@ -93,7 +91,7 @@ namespace RAWSimO.Core.Generator
         /// <param name="settingConfig">The configuration for the setting to emulate that will be attached for executing the simulation afterwards.</param>
         /// <param name="controlConfig">The configuration for the controlling mechanisms that will be attached for executing the simulation afterwards.</param>
         /// <returns>The generated instance.</returns>
-        public static Instance GenerateMaTiLayoutNano(IRandomizer rand, SettingConfiguration settingConfig, ControlConfiguration controlConfig)
+        public static Instance GenerateMaTiLayoutNano(SettingConfiguration settingConfig, ControlConfiguration controlConfig)
         {
             LayoutConfiguration layoutConfiguration = GenerateMaTiLayoutConfiguration();
             layoutConfiguration.BotCount = 8;
@@ -108,7 +106,7 @@ namespace RAWSimO.Core.Generator
             layoutConfiguration.NReplenishmentStationEast = 0;
             layoutConfiguration.NReplenishmentStationSouth = 0;
             layoutConfiguration.NReplenishmentStationNorth = 0;
-            return GenerateLayout(layoutConfiguration, rand, settingConfig, controlConfig);
+            return GenerateLayout(layoutConfiguration, settingConfig, controlConfig);
         }
         /// <summary>
         /// Generates the micro default layout.
@@ -117,7 +115,7 @@ namespace RAWSimO.Core.Generator
         /// <param name="settingConfig">The configuration for the setting to emulate that will be attached for executing the simulation afterwards.</param>
         /// <param name="controlConfig">The configuration for the controlling mechanisms that will be attached for executing the simulation afterwards.</param>
         /// <returns>The generated instance.</returns>
-        public static Instance GenerateMaTiLayoutMicro(IRandomizer rand, SettingConfiguration settingConfig, ControlConfiguration controlConfig)
+        public static Instance GenerateMaTiLayoutMicro(SettingConfiguration settingConfig, ControlConfiguration controlConfig)
         {
             LayoutConfiguration layoutConfiguration = GenerateMaTiLayoutConfiguration();
             layoutConfiguration.BotCount = 12;
@@ -132,7 +130,7 @@ namespace RAWSimO.Core.Generator
             layoutConfiguration.NReplenishmentStationEast = 0;
             layoutConfiguration.NReplenishmentStationSouth = 0;
             layoutConfiguration.NReplenishmentStationNorth = 0;
-            return GenerateLayout(layoutConfiguration, rand, settingConfig, controlConfig);
+            return GenerateLayout(layoutConfiguration, settingConfig, controlConfig);
         }
         /// <summary>
         /// Generates the milli default layout.
@@ -141,7 +139,7 @@ namespace RAWSimO.Core.Generator
         /// <param name="settingConfig">The configuration for the setting to emulate that will be attached for executing the simulation afterwards.</param>
         /// <param name="controlConfig">The configuration for the controlling mechanisms that will be attached for executing the simulation afterwards.</param>
         /// <returns>The generated instance.</returns>
-        public static Instance GenerateMaTiLayoutMilli(IRandomizer rand, SettingConfiguration settingConfig, ControlConfiguration controlConfig)
+        public static Instance GenerateMaTiLayoutMilli(SettingConfiguration settingConfig, ControlConfiguration controlConfig)
         {
             LayoutConfiguration layoutConfiguration = GenerateMaTiLayoutConfiguration();
             layoutConfiguration.BotCount = 16;
@@ -156,7 +154,7 @@ namespace RAWSimO.Core.Generator
             layoutConfiguration.NReplenishmentStationEast = 0;
             layoutConfiguration.NReplenishmentStationSouth = 0;
             layoutConfiguration.NReplenishmentStationNorth = 0;
-            return GenerateLayout(layoutConfiguration, rand, settingConfig, controlConfig);
+            return GenerateLayout(layoutConfiguration, settingConfig, controlConfig);
         }
         /// <summary>
         /// Generates the centi default layout.
@@ -165,7 +163,7 @@ namespace RAWSimO.Core.Generator
         /// <param name="settingConfig">The configuration for the setting to emulate that will be attached for executing the simulation afterwards.</param>
         /// <param name="controlConfig">The configuration for the controlling mechanisms that will be attached for executing the simulation afterwards.</param>
         /// <returns>The generated instance.</returns>
-        public static Instance GenerateMaTiLayoutCenti(IRandomizer rand, SettingConfiguration settingConfig, ControlConfiguration controlConfig)
+        public static Instance GenerateMaTiLayoutCenti(SettingConfiguration settingConfig, ControlConfiguration controlConfig)
         {
             LayoutConfiguration layoutConfiguration = GenerateMaTiLayoutConfiguration();
             layoutConfiguration.BotCount = 20;
@@ -180,7 +178,7 @@ namespace RAWSimO.Core.Generator
             layoutConfiguration.NReplenishmentStationEast = 0;
             layoutConfiguration.NReplenishmentStationSouth = 0;
             layoutConfiguration.NReplenishmentStationNorth = 0;
-            return GenerateLayout(layoutConfiguration, rand, settingConfig, controlConfig);
+            return GenerateLayout(layoutConfiguration, settingConfig, controlConfig);
         }
         /// <summary>
         /// Generates the deca default layout.
@@ -189,7 +187,7 @@ namespace RAWSimO.Core.Generator
         /// <param name="settingConfig">The configuration for the setting to emulate that will be attached for executing the simulation afterwards.</param>
         /// <param name="controlConfig">The configuration for the controlling mechanisms that will be attached for executing the simulation afterwards.</param>
         /// <returns>The generated instance.</returns>
-        public static Instance GenerateMaTiLayoutDeca(IRandomizer rand, SettingConfiguration settingConfig, ControlConfiguration controlConfig)
+        public static Instance GenerateMaTiLayoutDeca(SettingConfiguration settingConfig, ControlConfiguration controlConfig)
         {
             LayoutConfiguration layoutConfiguration = GenerateMaTiLayoutConfiguration();
             layoutConfiguration.BotCount = 24;
@@ -204,7 +202,7 @@ namespace RAWSimO.Core.Generator
             layoutConfiguration.NReplenishmentStationEast = 0;
             layoutConfiguration.NReplenishmentStationSouth = 0;
             layoutConfiguration.NReplenishmentStationNorth = 0;
-            return GenerateLayout(layoutConfiguration, rand, settingConfig, controlConfig);
+            return GenerateLayout(layoutConfiguration, settingConfig, controlConfig);
         }
         /// <summary>
         /// Generates the hecto default layout.
@@ -213,7 +211,7 @@ namespace RAWSimO.Core.Generator
         /// <param name="settingConfig">The configuration for the setting to emulate that will be attached for executing the simulation afterwards.</param>
         /// <param name="controlConfig">The configuration for the controlling mechanisms that will be attached for executing the simulation afterwards.</param>
         /// <returns>The generated instance.</returns>
-        public static Instance GenerateMaTiLayoutHecto(IRandomizer rand, SettingConfiguration settingConfig, ControlConfiguration controlConfig)
+        public static Instance GenerateMaTiLayoutHecto(SettingConfiguration settingConfig, ControlConfiguration controlConfig)
         {
             LayoutConfiguration layoutConfiguration = GenerateMaTiLayoutConfiguration();
             layoutConfiguration.BotCount = 28;
@@ -228,7 +226,7 @@ namespace RAWSimO.Core.Generator
             layoutConfiguration.NReplenishmentStationEast = 0;
             layoutConfiguration.NReplenishmentStationSouth = 0;
             layoutConfiguration.NReplenishmentStationNorth = 0;
-            return GenerateLayout(layoutConfiguration, rand, settingConfig, controlConfig);
+            return GenerateLayout(layoutConfiguration, settingConfig, controlConfig);
         }
         /// <summary>
         /// Generates the kilo default layout.
@@ -237,7 +235,7 @@ namespace RAWSimO.Core.Generator
         /// <param name="settingConfig">The configuration for the setting to emulate that will be attached for executing the simulation afterwards.</param>
         /// <param name="controlConfig">The configuration for the controlling mechanisms that will be attached for executing the simulation afterwards.</param>
         /// <returns>The generated instance.</returns>
-        public static Instance GenerateMaTiLayoutKilo(IRandomizer rand, SettingConfiguration settingConfig, ControlConfiguration controlConfig)
+        public static Instance GenerateMaTiLayoutKilo(SettingConfiguration settingConfig, ControlConfiguration controlConfig)
         {
             LayoutConfiguration layoutConfiguration = GenerateMaTiLayoutConfiguration();
             layoutConfiguration.BotCount = 32;
@@ -252,7 +250,7 @@ namespace RAWSimO.Core.Generator
             layoutConfiguration.NReplenishmentStationEast = 0;
             layoutConfiguration.NReplenishmentStationSouth = 0;
             layoutConfiguration.NReplenishmentStationNorth = 0;
-            return GenerateLayout(layoutConfiguration, rand, settingConfig, controlConfig);
+            return GenerateLayout(layoutConfiguration, settingConfig, controlConfig);
         }
         /// <summary>
         /// Generates the mega default layout.
@@ -261,7 +259,7 @@ namespace RAWSimO.Core.Generator
         /// <param name="settingConfig">The configuration for the setting to emulate that will be attached for executing the simulation afterwards.</param>
         /// <param name="controlConfig">The configuration for the controlling mechanisms that will be attached for executing the simulation afterwards.</param>
         /// <returns>The generated instance.</returns>
-        public static Instance GenerateMaTiLayoutMega(IRandomizer rand, SettingConfiguration settingConfig, ControlConfiguration controlConfig)
+        public static Instance GenerateMaTiLayoutMega(SettingConfiguration settingConfig, ControlConfiguration controlConfig)
         {
             LayoutConfiguration layoutConfiguration = GenerateMaTiLayoutConfiguration();
             layoutConfiguration.BotCount = 36;
@@ -276,7 +274,7 @@ namespace RAWSimO.Core.Generator
             layoutConfiguration.NReplenishmentStationEast = 0;
             layoutConfiguration.NReplenishmentStationSouth = 0;
             layoutConfiguration.NReplenishmentStationNorth = 0;
-            return GenerateLayout(layoutConfiguration, rand, settingConfig, controlConfig);
+            return GenerateLayout(layoutConfiguration, settingConfig, controlConfig);
         }
         /// <summary>
         /// Generates the giga default layout.
@@ -285,7 +283,7 @@ namespace RAWSimO.Core.Generator
         /// <param name="settingConfig">The configuration for the setting to emulate that will be attached for executing the simulation afterwards.</param>
         /// <param name="controlConfig">The configuration for the controlling mechanisms that will be attached for executing the simulation afterwards.</param>
         /// <returns>The generated instance.</returns>
-        public static Instance GenerateMaTiLayoutGiga(IRandomizer rand, SettingConfiguration settingConfig, ControlConfiguration controlConfig)
+        public static Instance GenerateMaTiLayoutGiga(SettingConfiguration settingConfig, ControlConfiguration controlConfig)
         {
             LayoutConfiguration layoutConfiguration = GenerateMaTiLayoutConfiguration();
             layoutConfiguration.BotCount = 40;
@@ -300,7 +298,7 @@ namespace RAWSimO.Core.Generator
             layoutConfiguration.NReplenishmentStationEast = 0;
             layoutConfiguration.NReplenishmentStationSouth = 0;
             layoutConfiguration.NReplenishmentStationNorth = 0;
-            return GenerateLayout(layoutConfiguration, rand, settingConfig, controlConfig);
+            return GenerateLayout(layoutConfiguration, settingConfig, controlConfig);
         }
 
         #endregion
@@ -314,7 +312,7 @@ namespace RAWSimO.Core.Generator
         /// <param name="settingConfig">The configuration for the setting to emulate that will be attached for executing the simulation afterwards.</param>
         /// <param name="controlConfig">The configuration for the controlling mechanisms that will be attached for executing the simulation afterwards.</param>
         /// <returns>The generated instance.</returns>
-        public static Instance GenerateMaTiLayoutTiny(IRandomizer rand, SettingConfiguration settingConfig, ControlConfiguration controlConfig)
+        public static Instance GenerateMaTiLayoutTiny(SettingConfiguration settingConfig, ControlConfiguration controlConfig)
         {
             LayoutConfiguration layoutConfiguration = GenerateMaTiLayoutConfiguration();
             layoutConfiguration.BotCount = 32;
@@ -329,7 +327,7 @@ namespace RAWSimO.Core.Generator
             layoutConfiguration.NReplenishmentStationEast = 0;
             layoutConfiguration.NReplenishmentStationSouth = 0;
             layoutConfiguration.NReplenishmentStationNorth = 0;
-            return GenerateLayout(layoutConfiguration, rand, settingConfig, controlConfig);
+            return GenerateLayout(layoutConfiguration, settingConfig, controlConfig);
         }
         /// <summary>
         /// Generates the tiny default layout.
@@ -338,7 +336,7 @@ namespace RAWSimO.Core.Generator
         /// <param name="settingConfig">The configuration for the setting to emulate that will be attached for executing the simulation afterwards.</param>
         /// <param name="controlConfig">The configuration for the controlling mechanisms that will be attached for executing the simulation afterwards.</param>
         /// <returns>The generated instance.</returns>
-        public static Instance GenerateMaTiLayoutSmall(IRandomizer rand, SettingConfiguration settingConfig, ControlConfiguration controlConfig)
+        public static Instance GenerateMaTiLayoutSmall(SettingConfiguration settingConfig, ControlConfiguration controlConfig)
         {
             LayoutConfiguration layoutConfiguration = GenerateMaTiLayoutConfiguration();
             layoutConfiguration.BotCount = 40;
@@ -353,7 +351,7 @@ namespace RAWSimO.Core.Generator
             layoutConfiguration.NReplenishmentStationEast = 0;
             layoutConfiguration.NReplenishmentStationSouth = 0;
             layoutConfiguration.NReplenishmentStationNorth = 0;
-            return GenerateLayout(layoutConfiguration, rand, settingConfig, controlConfig);
+            return GenerateLayout(layoutConfiguration, settingConfig, controlConfig);
         }
         /// <summary>
         /// Generates the tiny default layout.
@@ -362,7 +360,7 @@ namespace RAWSimO.Core.Generator
         /// <param name="settingConfig">The configuration for the setting to emulate that will be attached for executing the simulation afterwards.</param>
         /// <param name="controlConfig">The configuration for the controlling mechanisms that will be attached for executing the simulation afterwards.</param>
         /// <returns>The generated instance.</returns>
-        public static Instance GenerateMaTiLayoutMedium(IRandomizer rand, SettingConfiguration settingConfig, ControlConfiguration controlConfig)
+        public static Instance GenerateMaTiLayoutMedium(SettingConfiguration settingConfig, ControlConfiguration controlConfig)
         {
             LayoutConfiguration layoutConfiguration = GenerateMaTiLayoutConfiguration();
             layoutConfiguration.BotCount = 48;
@@ -377,7 +375,7 @@ namespace RAWSimO.Core.Generator
             layoutConfiguration.NReplenishmentStationEast = 0;
             layoutConfiguration.NReplenishmentStationSouth = 0;
             layoutConfiguration.NReplenishmentStationNorth = 0;
-            return GenerateLayout(layoutConfiguration, rand, settingConfig, controlConfig);
+            return GenerateLayout(layoutConfiguration, settingConfig, controlConfig);
         }
         /// <summary>
         /// Generates the tiny default layout.
@@ -386,7 +384,7 @@ namespace RAWSimO.Core.Generator
         /// <param name="settingConfig">The configuration for the setting to emulate that will be attached for executing the simulation afterwards.</param>
         /// <param name="controlConfig">The configuration for the controlling mechanisms that will be attached for executing the simulation afterwards.</param>
         /// <returns>The generated instance.</returns>
-        public static Instance GenerateMaTiLayoutLarge(IRandomizer rand, SettingConfiguration settingConfig, ControlConfiguration controlConfig)
+        public static Instance GenerateMaTiLayoutLarge(SettingConfiguration settingConfig, ControlConfiguration controlConfig)
         {
             LayoutConfiguration layoutConfiguration = GenerateMaTiLayoutConfiguration();
             layoutConfiguration.BotCount = 56;
@@ -401,7 +399,7 @@ namespace RAWSimO.Core.Generator
             layoutConfiguration.NReplenishmentStationEast = 0;
             layoutConfiguration.NReplenishmentStationSouth = 0;
             layoutConfiguration.NReplenishmentStationNorth = 0;
-            return GenerateLayout(layoutConfiguration, rand, settingConfig, controlConfig);
+            return GenerateLayout(layoutConfiguration, settingConfig, controlConfig);
         }
         /// <summary>
         /// Generates the tiny default layout.
@@ -410,7 +408,7 @@ namespace RAWSimO.Core.Generator
         /// <param name="settingConfig">The configuration for the setting to emulate that will be attached for executing the simulation afterwards.</param>
         /// <param name="controlConfig">The configuration for the controlling mechanisms that will be attached for executing the simulation afterwards.</param>
         /// <returns>The generated instance.</returns>
-        public static Instance GenerateMaTiLayoutHuge(IRandomizer rand, SettingConfiguration settingConfig, ControlConfiguration controlConfig)
+        public static Instance GenerateMaTiLayoutHuge(SettingConfiguration settingConfig, ControlConfiguration controlConfig)
         {
             LayoutConfiguration layoutConfiguration = GenerateMaTiLayoutConfiguration();
             layoutConfiguration.BotCount = 64;
@@ -425,7 +423,7 @@ namespace RAWSimO.Core.Generator
             layoutConfiguration.NReplenishmentStationEast = 0;
             layoutConfiguration.NReplenishmentStationSouth = 0;
             layoutConfiguration.NReplenishmentStationNorth = 0;
-            return GenerateLayout(layoutConfiguration, rand, settingConfig, controlConfig);
+            return GenerateLayout(layoutConfiguration, settingConfig, controlConfig);
         }
         /// <summary>
         /// Generates the default layout configuration.

--- a/RAWSimO.Core/Generator/LayoutGenerator.cs
+++ b/RAWSimO.Core/Generator/LayoutGenerator.cs
@@ -169,7 +169,7 @@ namespace RAWSimO.Core.Generator
                     Console.Write((
                         showRows ? i.ToString().PadLeft(maxRowIndexLength) :
                         showCols ? j.ToString().PadLeft(maxColIndexLength) :
-                        (tiles[i, j] != null ? tiles[i, j].directionAsString() : " ")) + 
+                        (tiles[i, j] != null ? tiles[i, j].directionAsString() : " ")) +
                         (j == tiles.GetLength(1) - 1 ? "" : " "));
                 Console.WriteLine();
             }
@@ -179,7 +179,6 @@ namespace RAWSimO.Core.Generator
 
         public LayoutGenerator(
             LayoutConfiguration layoutConfiguration,
-            IRandomizer rand,
             SettingConfiguration baseConfiguration,
             ControlConfiguration controlConfiguration,
             Action<string> logAction = null)
@@ -202,7 +201,7 @@ namespace RAWSimO.Core.Generator
                 throw new ArgumentException("ControlConfiguration is not valid. " + errorMessage);
             }
 
-            this.rand = rand;
+            this.rand = new RandomizerSimple(layoutConfiguration.Seed);
             this.baseConfiguration = baseConfiguration;
             elevatorPositions = new Dictionary<Tuple<double, double>, Elevator>();
             elevatorWaypoints = new Dictionary<Elevator, List<Waypoint>>();

--- a/RAWSimO.Core/IO/InstanceIO.cs
+++ b/RAWSimO.Core/IO/InstanceIO.cs
@@ -105,7 +105,7 @@ namespace RAWSimO.Core.IO
                     layoutConfig.ApplyOverrideConfig(settingConfig.OverrideConfig);
                 // Generate instance
                 logAction?.Invoke("Generating instance...");
-                instance = InstanceGenerator.GenerateLayout(layoutConfig, new RandomizerSimple(0), settingConfig, controlConfig, logAction);
+                instance = InstanceGenerator.GenerateLayout(layoutConfig, settingConfig, controlConfig, logAction);
             }
             else
             {

--- a/RAWSimO.Playground/Generators/InstanceGenerators.cs
+++ b/RAWSimO.Playground/Generators/InstanceGenerators.cs
@@ -15,30 +15,23 @@ namespace RAWSimO.Playground.Generators
     {
         public static void GenerateMaTiInstances()
         {
-            // Generate MaTi instances
-            RandomizerSimple random = new RandomizerSimple(0);
             // Generate original MaTi set
-            Instance tiny = InstanceGenerator.GenerateMaTiLayoutTiny(random, new SettingConfiguration(), new ControlConfiguration());
-            Instance small = InstanceGenerator.GenerateMaTiLayoutSmall(random, new SettingConfiguration(), new ControlConfiguration());
-            Instance medium = InstanceGenerator.GenerateMaTiLayoutMedium(random, new SettingConfiguration(), new ControlConfiguration());
-            Instance large = InstanceGenerator.GenerateMaTiLayoutLarge(random, new SettingConfiguration(), new ControlConfiguration());
-            Instance huge = InstanceGenerator.GenerateMaTiLayoutHuge(random, new SettingConfiguration(), new ControlConfiguration());
-            InstanceIO.WriteInstance("MaTiTiny.xinst", tiny);
-            InstanceIO.WriteInstance("MaTiSmall.xinst", small);
-            InstanceIO.WriteInstance("MaTiMedium.xinst", medium);
-            InstanceIO.WriteInstance("MaTiLarge.xinst", large);
-            InstanceIO.WriteInstance("MaTiHuge.xinst", huge);
+            InstanceIO.WriteInstance("MaTiTiny.xinst", InstanceGenerator.GenerateMaTiLayoutTiny(new SettingConfiguration(), new ControlConfiguration()));
+            InstanceIO.WriteInstance("MaTiSmall.xinst", InstanceGenerator.GenerateMaTiLayoutSmall(new SettingConfiguration(), new ControlConfiguration()));
+            InstanceIO.WriteInstance("MaTiMedium.xinst", InstanceGenerator.GenerateMaTiLayoutMedium(new SettingConfiguration(), new ControlConfiguration()));
+            InstanceIO.WriteInstance("MaTiLarge.xinst", InstanceGenerator.GenerateMaTiLayoutLarge(new SettingConfiguration(), new ControlConfiguration()));
+            InstanceIO.WriteInstance("MaTiHuge.xinst", InstanceGenerator.GenerateMaTiLayoutHuge(new SettingConfiguration(), new ControlConfiguration()));
             // Generate alternative MaTi set
-            InstanceIO.WriteInstance("MaTiPico.xinst", InstanceGenerator.GenerateMaTiLayoutPico(random, new SettingConfiguration(), new ControlConfiguration()));
-            InstanceIO.WriteInstance("MaTiNano.xinst", InstanceGenerator.GenerateMaTiLayoutNano(random, new SettingConfiguration(), new ControlConfiguration()));
-            InstanceIO.WriteInstance("MaTiMicro.xinst", InstanceGenerator.GenerateMaTiLayoutMicro(random, new SettingConfiguration(), new ControlConfiguration()));
-            InstanceIO.WriteInstance("MaTiMilli.xinst", InstanceGenerator.GenerateMaTiLayoutMilli(random, new SettingConfiguration(), new ControlConfiguration()));
-            InstanceIO.WriteInstance("MaTiCenti.xinst", InstanceGenerator.GenerateMaTiLayoutCenti(random, new SettingConfiguration(), new ControlConfiguration()));
-            InstanceIO.WriteInstance("MaTiDeca.xinst", InstanceGenerator.GenerateMaTiLayoutDeca(random, new SettingConfiguration(), new ControlConfiguration()));
-            InstanceIO.WriteInstance("MaTiHecto.xinst", InstanceGenerator.GenerateMaTiLayoutHecto(random, new SettingConfiguration(), new ControlConfiguration()));
-            InstanceIO.WriteInstance("MaTiKilo.xinst", InstanceGenerator.GenerateMaTiLayoutKilo(random, new SettingConfiguration(), new ControlConfiguration()));
-            InstanceIO.WriteInstance("MaTiMega.xinst", InstanceGenerator.GenerateMaTiLayoutMega(random, new SettingConfiguration(), new ControlConfiguration()));
-            InstanceIO.WriteInstance("MaTiGiga.xinst", InstanceGenerator.GenerateMaTiLayoutGiga(random, new SettingConfiguration(), new ControlConfiguration()));
+            InstanceIO.WriteInstance("MaTiPico.xinst", InstanceGenerator.GenerateMaTiLayoutPico(new SettingConfiguration(), new ControlConfiguration()));
+            InstanceIO.WriteInstance("MaTiNano.xinst", InstanceGenerator.GenerateMaTiLayoutNano(new SettingConfiguration(), new ControlConfiguration()));
+            InstanceIO.WriteInstance("MaTiMicro.xinst", InstanceGenerator.GenerateMaTiLayoutMicro(new SettingConfiguration(), new ControlConfiguration()));
+            InstanceIO.WriteInstance("MaTiMilli.xinst", InstanceGenerator.GenerateMaTiLayoutMilli(new SettingConfiguration(), new ControlConfiguration()));
+            InstanceIO.WriteInstance("MaTiCenti.xinst", InstanceGenerator.GenerateMaTiLayoutCenti(new SettingConfiguration(), new ControlConfiguration()));
+            InstanceIO.WriteInstance("MaTiDeca.xinst", InstanceGenerator.GenerateMaTiLayoutDeca(new SettingConfiguration(), new ControlConfiguration()));
+            InstanceIO.WriteInstance("MaTiHecto.xinst", InstanceGenerator.GenerateMaTiLayoutHecto(new SettingConfiguration(), new ControlConfiguration()));
+            InstanceIO.WriteInstance("MaTiKilo.xinst", InstanceGenerator.GenerateMaTiLayoutKilo(new SettingConfiguration(), new ControlConfiguration()));
+            InstanceIO.WriteInstance("MaTiMega.xinst", InstanceGenerator.GenerateMaTiLayoutMega(new SettingConfiguration(), new ControlConfiguration()));
+            InstanceIO.WriteInstance("MaTiGiga.xinst", InstanceGenerator.GenerateMaTiLayoutGiga(new SettingConfiguration(), new ControlConfiguration()));
         }
     }
 }

--- a/RAWSimO.Visualization/MainWindow.xaml.cs
+++ b/RAWSimO.Visualization/MainWindow.xaml.cs
@@ -1007,8 +1007,7 @@ namespace RAWSimO.Visualization
                 _baseConfiguration.VisualizationAttached = true;
 
                 // Generate
-                IRandomizer rand = new RandomizerSimple(0);
-                _instance = InstanceGenerator.GenerateLayout(_layoutConfig, rand, _baseConfiguration, _controlConfiguration);
+                _instance = InstanceGenerator.GenerateLayout(_layoutConfig, _baseConfiguration, _controlConfiguration);
                 _instanceInvalidated = false;
                 _instance.Name = _instance.GetMetaInfoBasedInstanceName();
 


### PR DESCRIPTION
# Description

Allows specifying a seed in the layout configuration. This seed is used for randomly positioning pods, bots, etc. Previously, stored layouts should be fully compatible as a missing seed acts as a `0` seed value, which was the previous fixed default.

The seed can be configured in the UI via _Instances > Instance layout > Seed_ and in the XML:

```xml
<LayoutConfiguration>
  ...
  <Seed>0</Seed>
  ...
</LayoutConfiguration>
```

> ⚠️ Note: This seed only affects the layout being generated. There is already a seed available to change the stream of random events for the running simulation. Find it in the _setting configuration_.

## Changes

- Allows defining seeded layouts